### PR TITLE
Importing great amounts of campaigns

### DIFF
--- a/class/MailchimpCampaigns.php
+++ b/class/MailchimpCampaigns.php
@@ -50,11 +50,18 @@ class MailchimpCampaigns extends Mailchimp
      */
     public function args( $args = array() ){
         $default_args = array(
-            // 'count' => 5,
-            // 'status' => 'sent',
+            //'count' => 5,
+            // 'status' => 'save',
             // 'fields' => array('id', 'type'),
+            'since_create_time' => isset( $this->settings['import_since'] ) ? (empty ($this->settings['import_since']) ? NULL : $this->settings['import_since'] ) : NULL,
+            'before_create_time' => isset( $this->settings['import_before'] ) ? (empty ($this->settings['import_before']) ? current_time('Y-m-d') : $this->settings['import_before']) : current_time('Y-m-d'),
+            //'since_send_time' => isset( $this->settings['import_since'] ) ? (empty ($this->settings['import_since']) ? NULL : $this->settings['import_since'] ) : NULL,
+            //'before_send_time' => isset( $this->settings['import_before'] ) ? (empty ($this->settings['import_before']) ? current_time('Y-m-d') : $this->settings['import_before']) : current_time('Y-m-d'),
         );
+
         $args = array_merge_recursive($default_args, $args);
+        $default_args = NULL;
+
         return $args;
     }
 
@@ -63,34 +70,62 @@ class MailchimpCampaigns extends Mailchimp
      */
     public function import($renew = true)
     {
-        if( $renew )
-            $this->fetch();
 
-        $cpt_name = empty($this->settings['cpt_name']) ? MCC_DEFAULT_CPT : $this->settings['cpt_name']; 
+        $totalCount = $this->getTotal();
 
-        $campaigns = $this->campaigns();
-        foreach( $campaigns as $i => $campaign){
-            $mcc = new MailchimpCampaign($campaign);
-            $mcc->init()->fetch()->save(); // Get content for this campaigns 
-            unset($campaigns[$i]); // Remove campaigns from array() just for fun
+        // Establish the number of items to be retrieved at each round
+
+        $countSize = 50;
+
+        // Establish the initial campaign to be imported in each round
+
+        $offsetSize = 0;
+
+        // Controls the number of items retrieved
+
+        $importCount = 0;
+
+        while ($importCount < $totalCount){
+
+           if (($totalCount - $importCount) < $countSize) $countSize = $totalCount - $importCount;
+           
+           if( $renew )
+               $this->fetch($countSize, $offsetSize);
+
+           $cpt_name = empty($this->settings['cpt_name']) ? MCC_DEFAULT_CPT : $this->settings['cpt_name'];
+
+           $campaigns = $this->campaigns();
+           foreach( $campaigns as $i => $campaign){
+               $mcc = new MailchimpCampaign($campaign);
+               $mcc->init()->fetch()->save(); // Get content for this campaigns
+               unset($campaigns[$i]); // Remove campaigns from array() just for fun
+           }
+
+            $importCount += $this->count();
+
+            $offsetSize += $this->count();
+
         }
+
         // Display result
-        $this->admin_notice(__( $this->count() . ' campaigns have been imported.<br/>See the <a href="/wp-admin/edit.php?post_type='.$cpt_name.'">list</a>', MCC_TEXT_DOMAIN) );
-    }
+        $this->admin_notice(__( $importCount . ' campaigns have been imported.<br/>See the <a href="/wp-admin/edit.php?post_type='.$cpt_name.'">list</a>', MCC_TEXT_DOMAIN) );
+
+
+   }
 
     /**
      *
      */
-    public function fetch($args = array())
+    public function fetch($countSize = 50, $offsetSize = 0,$args = array())
     {
         // Get the total number of items to retrieve 
-        $count = $this->getTotal();
-        $args = $this->args(array('count'=>$count));
+        // $count = $this->getTotal();
+        $args = $this->args(array('count'=>$countSize,'offset'=>$offsetSize));
         $results = $this->call('campaigns', $args);
         $this->campaigns = json_decode( $results->last_call['body'] );
         
         // Update the time 
-        $this->last_updated = current_time( 'mysql' );
+        // $this->last_updated = current_time( 'mysql' );
     }
 
     /**


### PR DESCRIPTION
Hi Mathieu

As promissed I'm providing a workaround for greater campaign amount imports.

I managed to bypass the problem setting the amount of posts imported ($countSize) at a time to 50 and setting an Offset ($offsetSize) so the plugin will be able to import. As I told earlier the plugin fails to import more than 70 campaigns returning a "fsocket timed out" error.

Also implemented a loop in import function so the plugin can control the section being imported and the total amount of imported campaign.

The $countSize and $offsetSize variables are passed to fetch function as arguments.

May need to adjust max_execution_time at PHP.ini

My mailchimp account has, by now, 286 campaigns (203 sent). The import works for wordpress 4.9.9 and 5.0.3 on partial imports, but fails to finish correctly in full import for version 5.03. There are no Fatal Errors on debug.log but the system returns "503 Service Unavailable" error.

For a alternative solution, and since I don't have any clue of what's happening, I decided to implement the use of since_create_time and before_create_time parameters.

By I still want to implement date validation for admin form. But I here submit the changes already done as a draft so you can evaluate and validate them

Look for the modifications on MailchimpCampaigns.php and MailchimpAdmin.php.

Feel free to contact me in my e-mail if you have any questions

Sérgio Leser